### PR TITLE
refactor: simplify admin id param handling

### DIFF
--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -5,9 +5,9 @@ import { requireAdmin } from "@/lib/adminAuth";
 
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id: string }> } // ⬅️ note la Promise ici
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params; // ⬅️ on résout la Promise
+  const { id } = params;
 
   const auth = requireAdmin(req); // si requireAdmin est async => await requireAdmin(req)
   if (!auth.ok) {


### PR DESCRIPTION
## Summary
- remove Promise from admin GET route params
- access id directly from params object

## Testing
- `npm test` *(fails: No test files found)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1b65ffcf8833180fa008b1296dd81