### PR TITLE
Improve form validation error handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -530,9 +530,19 @@ const isDebug = sp?.get("debug") === "1";
       const parsed = QuoteRequestSchema.safeParse(dataForServer);
       if (!parsed.success) {
         console.error(parsed.error.flatten());
-        alert("Certaines informations sont manquantes ou invalides. Vérifiez le formulaire.");
+        const issue = parsed.error.issues[0];
+        const rootPath = issue?.path?.[0];
+        const step: StepId =
+          rootPath === "customer" ||
+          rootPath === "project" ||
+          rootPath === "consentRgpd"
+            ? "contact"
+            : rootPath === "files"
+            ? "recap"
+            : "items";
+        setSubmitError(issue?.message || "Certaines informations sont manquantes ou invalides.");
         setIsSubmitting(false);
-        jumpTo("items");
+        jumpTo(step);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Jump to the relevant step when server-side validation fails
- Surface the first validation issue as a global error message

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c2416ee88331a3f31d5482bababa