### PR TITLE
Improve form validation and API error handling

### DIFF
--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -5,9 +5,9 @@ import { requireAdmin } from "@/lib/adminAuth";
 
 export async function GET(
   req: Request,
-  ctx: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await ctx.params;
+  const { id } = params;
 
   const auth = requireAdmin(req);
   if (!auth.ok) {

--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -5,9 +5,9 @@ import { requireAdmin } from "@/lib/adminAuth";
 
 export async function GET(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = params;
+  const { id } = await params;
 
   const auth = requireAdmin(req);
   if (!auth.ok) {

--- a/src/app/api/quote/route.ts
+++ b/src/app/api/quote/route.ts
@@ -153,12 +153,16 @@ export async function POST(req: Request) {
         <img src="https://picsum.photos/seed/anderlechtdecor/600/400" alt="test"/>
       </div>`;
     if (resend) {
-      await resend.emails.send({
-        from: SENDER_EMAIL,
-        to: [RECEIVER_EMAIL],
-        subject: "🧪 Test Images Email (imgdebug)",
-        html,
-      });
+      try {
+        await resend.emails.send({
+          from: SENDER_EMAIL,
+          to: [RECEIVER_EMAIL],
+          subject: "🧪 Test Images Email (imgdebug)",
+          html,
+        });
+      } catch (e) {
+        console.error("[api/quote] imgdebug email error", e);
+      }
     }
     return json({ ok: true, note: "Email test images envoyé" });
   }

--- a/src/components/forms/StoreItemRepeater.tsx
+++ b/src/components/forms/StoreItemRepeater.tsx
@@ -73,6 +73,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <select
             {...register(`items.${index}.type` as const)}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.type ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.type}
           >
             <option value="ROLLER">Enrouleur</option>
             <option value="VENETIAN">Vénitien</option>
@@ -95,6 +96,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
             min={1}
             {...register(`items.${index}.quantity` as const, { valueAsNumber: true })}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.quantity ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.quantity}
           />
           {itemErrors?.quantity?.message && (
             <p className="mt-1 text-xs text-red-500">
@@ -109,6 +111,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <select
             {...register(`items.${index}.mount` as const)}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.mount ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.mount}
           >
             <option value="INSIDE">Intérieur</option>
             <option value="OUTSIDE">Extérieur</option>
@@ -126,6 +129,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <select
             {...register(`items.${index}.windowType` as const)}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.windowType ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.windowType}
           >
             <option value="">—</option>
             <option value="WINDOW_SINGLE">Fenêtre</option>
@@ -148,6 +152,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <select
             {...register(`items.${index}.room` as const)}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.room ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.room}
           >
             <option value="">—</option>
             <option value="LIVING">Salon</option>
@@ -172,6 +177,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
               type="text"
               {...register(`items.${index}.roomLabel` as const)}
               className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.roomLabel ? "border-red-500" : "border-border"}`}
+              aria-invalid={!!itemErrors?.roomLabel}
             />
             {itemErrors?.roomLabel?.message && (
               <p className="mt-1 text-xs text-red-500">
@@ -187,6 +193,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <select
             {...register(`items.${index}.control` as const)}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.control ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.control}
             onChange={(e) => {
               if (e.target.value !== "MOTOR") {
                 // on vide le bloc motor si on n'est plus en motorisation
@@ -212,6 +219,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
               <select
                 {...register(`items.${index}.motor.power` as const)}
                 className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.motor?.power ? "border-red-500" : "border-border"}`}
+                aria-invalid={!!itemErrors?.motor?.power}
               >
                 <option value="">—</option>
                 <option value="WIRED">Filaire</option>
@@ -230,6 +238,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
                 type="text"
                 {...register(`items.${index}.motor.brand` as const)}
                 className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.motor?.brand ? "border-red-500" : "border-border"}`}
+                aria-invalid={!!itemErrors?.motor?.brand}
               />
               {itemErrors?.motor?.brand?.message && (
                 <p className="mt-1 text-xs text-red-500">
@@ -249,6 +258,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
             max={5000}
             {...register(`items.${index}.dims.width` as const, { valueAsNumber: true })}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.dims?.width ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.dims?.width}
           />
           {itemErrors?.dims?.width?.message && (
             <p className="mt-1 text-xs text-red-500">
@@ -264,6 +274,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
             max={5000}
             {...register(`items.${index}.dims.height` as const, { valueAsNumber: true })}
             className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.dims?.height ? "border-red-500" : "border-border"}`}
+            aria-invalid={!!itemErrors?.dims?.height}
           />
           {itemErrors?.dims?.height?.message && (
             <p className="mt-1 text-xs text-red-500">
@@ -280,6 +291,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           {...register(`items.${index}.notes` as const)}
           className={`w-full rounded-xl border bg-transparent px-3 py-2 text-sm ${itemErrors?.notes ? "border-red-500" : "border-border"}`}
           rows={3}
+          aria-invalid={!!itemErrors?.notes}
         />
         {itemErrors?.notes?.message && (
           <p className="mt-1 text-xs text-red-500">


### PR DESCRIPTION
## Summary
- streamline step validation using React Hook Form's `trigger` and centralized field mapping
- surface field errors with proper ARIA attributes in form components
- wrap Resend email sending in safe try/catch and simplify admin route params

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1d0eebea48331926ebf383dbef516