### PR TITLE
feat: add brand palette, typography and layout components

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -20,7 +20,7 @@ export default function AdminLoginPage() {
 
   return (
     <main className="mx-auto max-w-sm p-6">
-      <h2 className="mb-4 text-lg font-semibold">Connexion admin</h2>
+      <h2 className="mb-4">Connexion admin</h2>
       <form onSubmit={onSubmit} className="space-y-3">
         <input
           type="password"
@@ -29,7 +29,7 @@ export default function AdminLoginPage() {
           placeholder="Admin token"
           className="w-full rounded-xl border border-border bg-transparent px-3 py-2 text-sm"
         />
-        <button className="rounded-xl bg-[hsl(var(--brand))] px-4 py-2 text-sm font-semibold text-[hsl(var(--brand-foreground))]">
+        <button className="rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground">
           Se connecter
         </button>
       </form>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,17 @@
 import "./../styles/globals.css";
 import type { ReactNode } from "react";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 export const metadata = { title: "Devis Stores — Anderlecht Décor", description: "Estimation stores Bandalux" };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr">
-      <body className="bg-bg text-fg min-h-screen antialiased">
-        <div className="mx-auto max-w-5xl p-4">{children}</div>
+      <body className="bg-bg text-fg min-h-screen antialiased flex flex-col">
+        <Header />
+        <div className="mx-auto w-full max-w-5xl flex-1 p-4">{children}</div>
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -610,7 +610,7 @@ const isDebug = sp?.get("debug") === "1";
         noValidate
         aria-live="polite"
       >
-        <h1 className="mb-4 text-2xl font-bold">Devis Stores</h1>
+        <h1 className="mb-4">Devis Stores</h1>
         <Stepper steps={stepperData} current={currentIdx} />
 
         <div className="mt-6">
@@ -642,7 +642,7 @@ const isDebug = sp?.get("debug") === "1";
               onClick={goBack}
               disabled={currentIdx === 0 || isSubmitting}
               className={cn(
-                "rounded-xl border border-border px-4 py-2 text-sm hover:bg-black/5 dark:hover:bg:white/10 focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]",
+                "rounded-xl border border-brand px-4 py-2 text-sm text-brand hover:bg-brand-alt focus:outline-none focus:ring-2 focus:ring-brand",
                 (currentIdx === 0 || isSubmitting) && "opacity-50"
               )}
             >
@@ -653,7 +653,7 @@ const isDebug = sp?.get("debug") === "1";
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="rounded-xl bg-[hsl(var(--brand))] px-5 py-2 text-sm font-semibold text-[hsl(var(--brand-foreground))] hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[hsl(var(--brand))] disabled:opacity-60"
+                className="rounded-xl bg-brand px-5 py-2 text-sm font-semibold text-brand-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand disabled:opacity-60"
               >
                 {isSubmitting ? "Envoi…" : "Envoyer la demande"}
               </button>
@@ -662,7 +662,7 @@ const isDebug = sp?.get("debug") === "1";
                 type="button"
                 onClick={(e) => goNext(e)}
                 disabled={isSubmitting}
-                className="rounded-xl bg-[hsl(var(--brand))] px-5 py-2 text-sm font-semibold text-[hsl(var(--brand-foreground))] hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[hsl(var(--brand))] disabled:opacity-60"
+                className="rounded-xl bg-brand px-5 py-2 text-sm font-semibold text-brand-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand disabled:opacity-60"
               >
                 Continuer
               </button>
@@ -703,7 +703,7 @@ function StepIntro({ onStart }: { onStart: () => void }) {
         <button
           type="button"
           onClick={onStart}
-          className="rounded-xl bg-[hsl(var(--brand))] px-5 py-2 text-sm font-semibold text-[hsl(var(--brand-foreground))] hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[hsl(var(--brand))]"
+          className="rounded-xl bg-brand px-5 py-2 text-sm font-semibold text-brand-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand"
         >
           Commencer
         </button>
@@ -776,7 +776,7 @@ function StepQuantity({ onEnsureItems }: { onEnsureItems: (n: number) => void })
   return (
     <section className="space-y-4">
       <div className="flex items-center gap-2">
-        <h2 className="text-lg font-semibold">Combien de stores ?</h2>
+        <h2>Combien de stores ?</h2>
         <HelpTooltip content="Indiquez un nombre approximatif si nécessaire. Vous pourrez ajuster ensuite." />
       </div>
 
@@ -808,7 +808,7 @@ function StepItems() {
   return (
     <section className="space-y-4">
       <div className="flex items-center gap-2">
-        <h2 className="text-lg font-semibold">Détails des stores</h2>
+        <h2>Détails des stores</h2>
         <HelpTooltip
           content={`Indiquez la mesure en mm !`}
         />
@@ -829,7 +829,7 @@ function StepContact() {
 
   return (
     <section className="space-y-4">
-      <h2 className="text-lg font-semibold">Vos coordonnées</h2>
+      <h2>Vos coordonnées</h2>
       <p className="mt-2 text-xs text-muted">* Champs Obligatoires</p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div>
@@ -1181,7 +1181,7 @@ function StepRecap({ onEdit }: { onEdit: (id: StepId) => void }) {
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Vérification</h2>
+        <h2>Vérification</h2>
       </div>
 
       {/* Coordonnées */}
@@ -1292,7 +1292,7 @@ function StepRecap({ onEdit }: { onEdit: (id: StepId) => void }) {
 function StepDone() {
   return (
     <section className="space-y-3 text-center">
-      <h2 className="text-lg font-semibold">Merci 🙌</h2>
+      <h2>Merci 🙌</h2>
       <p className="text-sm text-muted">
         Votre demande a été envoyée. Nous reviendrons vers vous rapidement
         !

--- a/src/app/page_OLD.tsx
+++ b/src/app/page_OLD.tsx
@@ -2,9 +2,14 @@ import Link from "next/link";
 export default function HomePage() {
   return (
     <main className="space-y-4">
-      <h1 className="text-2xl font-bold">Anderlecht Décor — Devis Stores</h1>
+      <h1>Anderlecht Décor — Devis Stores</h1>
       <p className="text-muted">Démarrez votre demande en ligne (2–3 min).</p>
-      <Link href="/devis" className="inline-block rounded-xl bg-[hsl(var(--brand))] px-5 py-2 text-sm font-semibold text-[hsl(var(--brand-foreground))]">Commencer le devis</Link>
+      <Link
+        href="/devis"
+        className="inline-block rounded-xl bg-brand px-5 py-2 text-sm font-semibold text-brand-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-brand"
+      >
+        Commencer le devis
+      </Link>
     </main>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,23 @@
+export default function Footer() {
+  return (
+    <footer className="mt-8 bg-primary-alt text-brand-foreground">
+      <div className="mx-auto max-w-5xl p-4 text-sm">
+        <p>Anderlecht Décor • Rue Exemple 1, 1000 Bruxelles</p>
+        <p>
+          <a href="mailto:contact@example.com" className="hover:text-brand">
+            contact@example.com
+          </a>
+        </p>
+        <div className="mt-2 flex gap-4">
+          <a href="#" aria-label="Twitter" className="hover:text-brand">
+            Twitter
+          </a>
+          <a href="#" aria-label="Facebook" className="hover:text-brand">
+            Facebook
+          </a>
+        </div>
+        <p className="mt-2 text-xs">© {new Date().getFullYear()} Anderlecht Décor. Tous droits réservés.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="bg-primary text-brand-foreground">
+      <div className="mx-auto flex max-w-5xl items-center justify-between p-4">
+        <Link href="/" className="text-lg font-bold hover:text-brand-alt">
+          Anderlecht Décor
+        </Link>
+        <nav>
+          <ul className="flex gap-4 text-sm">
+            <li>
+              <Link href="/devis" className="hover:text-brand-alt">
+                Devis
+              </Link>
+            </li>
+            <li>
+              <Link href="/contact" className="hover:text-brand-alt">
+                Contact
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/forms/FileDrop.tsx
+++ b/src/components/forms/FileDrop.tsx
@@ -176,7 +176,7 @@ export default function FileDrop({
         className={[
           "relative flex min-h-[120px] w-full cursor-pointer flex-col items-center justify-center rounded-2xl border border-dashed p-4 text-center outline-none transition",
           drag
-            ? "border-[hsl(var(--brand))] bg-[hsl(var(--brand))/0.05]"
+            ? "border-brand bg-brand-alt"
             : "border-border hover:bg-black/5 dark:hover:bg-white/5",
           error ? "ring-2 ring-red-500/50" : "",
         ].join(" ")}
@@ -243,7 +243,7 @@ export default function FileDrop({
                   <button
                     type="button"
                     onClick={() => onRemove(idx)}
-                    className="rounded-md border border-border px-2 py-1 text-xs hover:bg-black/5 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]"
+                    className="rounded-md border border-border px-2 py-1 text-xs hover:bg-brand-alt focus:outline-none focus:ring-2 focus:ring-brand"
                     aria-label={`Supprimer ${f.name}`}
                   >
                     Supprimer

--- a/src/components/forms/StoreItemRepeater.tsx
+++ b/src/components/forms/StoreItemRepeater.tsx
@@ -32,7 +32,7 @@ export default function StoreItemRepeater() {
             notes: "",
           } as any)
         }
-        className="rounded-xl border border-border px-4 py-2 text-sm hover:bg-black/5 dark:hover:bg-white/10"
+        className="rounded-xl border border-brand bg-brand-alt px-4 py-2 text-sm text-brand-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-brand"
       >
         + Ajouter un store
       </button>
@@ -59,7 +59,7 @@ function ItemCard({ index, onRemove }: { index: number; onRemove: () => void }) 
           <button
             type="button"
             onClick={onRemove}
-            className="rounded-md border border-border px-2 py-1 text-xs hover:bg-black/5 dark:hover:bg-white/10"
+            className="rounded-md border border-brand px-2 py-1 text-xs hover:bg-brand-alt focus:outline-none focus:ring-2 focus:ring-brand"
           >
             Supprimer
           </button>

--- a/src/components/ui/HelpTooltip.tsx
+++ b/src/components/ui/HelpTooltip.tsx
@@ -40,7 +40,7 @@ export default function HelpTooltip({
       <button
         ref={btnRef}
         type="button"
-        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border text-xs text-muted hover:text-fg hover:border-fg focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]"
+        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border text-xs text-muted hover:text-fg hover:border-fg focus:outline-none focus:ring-2 focus:ring-brand"
         aria-describedby={open ? tipId : undefined}
         aria-label={typeof label === "string" ? label : "Aide"}
         onMouseEnter={() => setOpen(true)}

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -58,9 +58,9 @@ export default function Stepper({
       </div>
 
       {showProgressBar && (
-        <div className="relative h-2 w-full overflow-hidden rounded-full bg-border" aria-label={ariaLabel}>
+        <div className="relative h-2 w-full overflow-hidden rounded-full bg-brand-alt" aria-label={ariaLabel}>
           <motion.div
-            className="h-2 rounded-full bg-[hsl(var(--brand))]"
+            className="h-2 rounded-full bg-brand"
             initial={{ width: 0 }}
             animate={{ width: `${pct}%` }}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
@@ -77,8 +77,8 @@ export default function Stepper({
               <div
                 className={cn(
                   "flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold",
-                  isDone && "bg-[hsl(var(--brand))] text-[hsl(var(--brand-foreground))] border-transparent",
-                  isCurrent && !isDone && "border-[hsl(var(--brand))] text-[hsl(var(--brand))]",
+                  isDone && "bg-brand text-brand-foreground border-transparent",
+                  isCurrent && !isDone && "border-brand text-brand",
                   !isCurrent && !isDone && "border-border text-muted"
                 )}
                 aria-current={isCurrent ? "step" : undefined}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,4 @@
-
+@import url('https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
 :root{
   --bg: 0 0% 100%;
@@ -6,6 +6,7 @@
   --muted: 215 16% 47%;
   --border: 214 32% 91%;
   --brand: 220 90% 56%;
+  --brand-alt: 220 90% 65%;
   --brand-foreground: 0 0% 100%;
 }
 :root.dark{
@@ -14,9 +15,19 @@
   --muted: 215 20% 65%;
   --border: 217 33% 17%;
   --brand: 220 90% 56%;
+  --brand-alt: 220 90% 65%;
   --brand-foreground: 0 0% 100%;
 }
 .text-muted{ color: hsl(var(--muted)); }
 .bg-bg{ background-color: hsl(var(--bg)); }
 .text-fg{ color: hsl(var(--fg)); }
 .border-border{ border-color: hsl(var(--border)); }
+
+@layer base {
+  body { font-family: sans-serif; }
+  h1, h2, h3, h4, h5, h6 { font-family: "Lora", serif; }
+  h1 { @apply text-4xl font-bold text-brand; }
+  h2 { @apply text-3xl font-semibold; }
+  p  { @apply leading-relaxed; }
+  a  { @apply text-brand underline hover:text-brand-alt; }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,13 +2,20 @@ import type { Config } from "tailwindcss";
 export default {
   darkMode: "class",
   content: ["./src/**/*.{ts,tsx}"],
-  theme: { extend: {
-    colors: {
-      bg: "hsl(var(--bg))",
-      fg: "hsl(var(--fg))",
-      muted: "hsl(var(--muted))",
-      border: "hsl(var(--border))"
+  theme: {
+    extend: {
+      colors: {
+        bg: "hsl(var(--bg))",
+        fg: "hsl(var(--fg))",
+        muted: "hsl(var(--muted))",
+        border: "hsl(var(--border))",
+        brand: "hsl(var(--brand))",
+        "brand-alt": "hsl(var(--brand-alt))",
+        "brand-foreground": "hsl(var(--brand-foreground))",
+        primary: "hsl(var(--brand))",
+        "primary-alt": "hsl(var(--brand-alt))"
+      }
     }
-  }},
+  },
   plugins: []
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add brand and primary color tokens to tailwind config
- import Lora font, set global typography and variables
- introduce Header and Footer components and wire into layout
- restyle forms and Stepper with brand colors

## Testing
- `pnpm test` (fails: No test files found)
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1dbe5e6388331982ee1a08c8f9698